### PR TITLE
Use reverse instead of string-reverse for newer Emacs

### DIFF
--- a/company-mlton.el
+++ b/company-mlton.el
@@ -158,12 +158,12 @@ return it.
 If point is in the middle of a prefix of an SML long identifier,
 return 'stop.
 Otherwise, return 'nil."
-  (let ((rev-pre-line (string-reverse
+  (let ((rev-pre-line (reverse
                        (buffer-substring-no-properties (point-at-bol) (point)))))
     (when (string-match
            company-mlton--rev-prefix-sml-long-id-at-start-re
            rev-pre-line)
-      (let ((prefix (string-reverse
+      (let ((prefix (reverse
                      (match-string-no-properties 0 rev-pre-line))))
         ;; match must succeed
         (string-match


### PR DESCRIPTION
`string-reverse` is a deprecated function since Emacs 25.1.

```
In company-mlton--prefix:
company-mlton.el:161:24:Warning: ‘string-reverse’ is an obsolete function (as
    of 25.1); use ‘reverse’ instead.
company-mlton.el:165:12:Warning: ‘string-reverse’ is an obsolete function (as
    of 25.1); use ‘reverse’ instead.
```